### PR TITLE
fixed error with unorderable types

### DIFF
--- a/src/sact/recipe/postgresql/__init__.py
+++ b/src/sact/recipe/postgresql/__init__.py
@@ -219,7 +219,7 @@ class Recipe:
             version = open(os.path.join(self.datadir,
                                         'PG_VERSION')).read()
         except IOError:
-            version = None
+            version = ''
 
         return version
 


### PR DESCRIPTION
I've got this error on python3.5, I'm not sure if this fix is correct but it worked out for me. Thank you for this recipe :)


While:                                                                                                                  
  Installing pgsql.                                                                                                     
                                                                                                                        
An internal error occurred due to a bug in either zc.buildout or in a                                                   
recipe being used:                                                                                                      
Traceback (most recent call last):                                                                                      
  File "/home/enkidulan/.buildout/eggs/zc.buildout-2.4.4-py3.4.egg/zc/buildout/buildout.py", line 1992, in main         
    getattr(buildout, command)(args)                                                                                    
  File "/home/enkidulan/.buildout/eggs/zc.buildout-2.4.4-py3.4.egg/zc/buildout/buildout.py", line 666, in install       
    installed_files = self[part]._call(recipe.install)                                                                  
  File "/home/enkidulan/.buildout/eggs/zc.buildout-2.4.4-py3.4.egg/zc/buildout/buildout.py", line 1407, in _call        
    return f()                                                                                                          
  File "/home/enkidulan/.buildout/eggs/sact.recipe.postgresql-0.10.0-py3.4.egg/sact/recipe/postgresql/__init__.py", line
 52, in install                                                                                                         
    self._make_pg_config()                                                                                              
  File "/home/enkidulan/.buildout/eggs/sact.recipe.postgresql-0.10.0-py3.4.egg/sact/recipe/postgresql/__init__.py", line
 245, in _make_pg_config                                                                                                
    admin=self.options['admin'] or 'postgres'                                                                           
  File "/home/enkidulan/.buildout/eggs/Jinja2-2.8-py3.4.egg/jinja2/environment.py", line 989, in render                 
    return self.environment.handle_exception(exc_info, True)                                                            
  File "/home/enkidulan/.buildout/eggs/Jinja2-2.8-py3.4.egg/jinja2/environment.py", line 754, in handle_exception       
    reraise(exc_type, exc_value, tb)                                                                                    
  File "/home/enkidulan/.buildout/eggs/Jinja2-2.8-py3.4.egg/jinja2/_compat.py", line 37, in reraise                     
    raise value.with_traceback(tb)                                                                                      
  File "<template>", line 1, in top-level template 
  TypeError: unorderable types: NoneType() < str()